### PR TITLE
feature: Create branch_judge component to switch branch type & support bne

### DIFF
--- a/asm/rom.asm
+++ b/asm/rom.asm
@@ -3,6 +3,8 @@ start:
     addiu $v0, $zero, 1
     nop
     addi $v0, $v0, 1
+    addi $t0, $v0, 1
+    bne $0, $v0, end
     addu $v0, $v0, $v0
     j end
 end:

--- a/src/MINI_CPU.sv
+++ b/src/MINI_CPU.sv
@@ -95,8 +95,8 @@ assign wd3 = result;
 
 // Increment Program Counter
 logic pc_src;
-logic branch;
-assign pc_src = zero & branch;
+logic [1:0] branch;
+branch_judge branch_judge_u(.branch, .zero, .y(pc_src));
 
 logic [31:0] pc_plus_4;
 logic [31:0] pc_branch;

--- a/src/MINI_CPU_tb.sv
+++ b/src/MINI_CPU_tb.sv
@@ -21,7 +21,7 @@ end
 
 initial begin
   rst = 1; #1; rst = 0;
-  #10;
+  #30;
   $finish;
 end
 

--- a/src/branch_judge.sv
+++ b/src/branch_judge.sv
@@ -1,0 +1,16 @@
+module branch_judge(
+  input var logic [1:0] branch,
+  input var logic zero,
+  output var logic y
+);
+
+always_comb begin
+  case (branch)
+    2'b00: y = 0;
+    2'b01: y = zero;
+    2'b11: y = ~zero;
+    default: y = 0;
+  endcase
+end
+
+endmodule

--- a/src/control_unit.sv
+++ b/src/control_unit.sv
@@ -3,7 +3,7 @@ module control_unit(
   input var logic [5:0] funct,
   output var logic mem_to_reg,
   output var logic mem_write,
-  output var logic branch,
+  output var logic [1:0] branch,
   output var logic alu_src,
   output var logic reg_dst,
   output var logic reg_write,
@@ -25,7 +25,7 @@ always_comb begin
     6'b000000: begin
       reg_write <= 1;
       reg_dst <= 1;
-      branch <= 0;
+      branch <= 2'b00;
       mem_write <= 0;
       mem_to_reg <= 0;
       alu_op <= 2'b10;
@@ -42,7 +42,7 @@ always_comb begin
       reg_write <= 1;
       reg_dst <= 0;
       alu_src <= 1;
-      branch <= 0;
+      branch <= 2'b00;
       mem_write <= 0;
       mem_to_reg <= 1;
       alu_op <= 2'b00;
@@ -53,7 +53,7 @@ always_comb begin
       reg_write <= 0;
       reg_dst <= 1'bx;
       alu_src <= 1;
-      branch <= 0;
+      branch <= 2'b00;
       mem_write <= 1;
       mem_to_reg <= 1'bx;
       alu_op <= 2'b00;
@@ -64,7 +64,18 @@ always_comb begin
       reg_write <= 0;
       reg_dst <= 1'bx;
       alu_src <= 0;
-      branch <= 1;
+      branch <= 2'b01;
+      mem_write <= 0;
+      mem_to_reg <= 1'bx;
+      alu_op <= 2'b01;
+      jump <= 0;
+    end
+    // bne
+    6'b000101: begin
+      reg_write <= 0;
+      reg_dst <= 1'bx;
+      alu_src <= 0;
+      branch <= 2'b11;
       mem_write <= 0;
       mem_to_reg <= 1'bx;
       alu_op <= 2'b01;
@@ -75,7 +86,7 @@ always_comb begin
       reg_write <= 1;
       reg_dst <= 0;
       alu_src <= 1;
-      branch <= 0;
+      branch <= 2'b00;
       mem_write <= 0;
       mem_to_reg <= 0;
       alu_op <= 2'b00;
@@ -86,7 +97,7 @@ always_comb begin
       reg_write <= 0;
       reg_dst <= 1'bx;
       alu_src <= 1'bx;
-      branch <= 1'bx;
+      branch <= 2'bxx;
       mem_write <= 0;
       mem_to_reg <= 1'bx;
       alu_op <= 2'bxx;
@@ -96,7 +107,7 @@ always_comb begin
       reg_write <= 1'bx;
       reg_dst <= 1'bx;
       alu_src <= 1'bx;
-      branch <= 1'bx;
+      branch <= 2'bxx;
       mem_write <= 1'bx;
       mem_to_reg <= 1'bx;
       alu_op <= 2'bxx;


### PR DESCRIPTION
# 目的

#3 

`bne` をサポートしたい

# やった事

ブランチする規準を切りかえられるように `branch_judge` というコンポーネントをつくった。
これによって、beqとして動作するかbneとして動作するかを切りかえられる