### PR TITLE
feature: Support jal

### DIFF
--- a/asm/rom.asm
+++ b/asm/rom.asm
@@ -4,7 +4,9 @@ start:
     nop
     addi $v0, $v0, 1
     addi $t0, $v0, 1
-    bne $0, $v0, end
+    jal hoge
+hoge:
+    bne $t0, $v0, end
     addu $v0, $v0, $v0
     j end
 end:

--- a/src/control_unit.sv
+++ b/src/control_unit.sv
@@ -2,10 +2,12 @@ module control_unit(
   input var logic [5:0] op,
   input var logic [5:0] funct,
   output var logic mem_to_reg,
+  output var logic pc_to_reg,
   output var logic mem_write,
   output var logic [1:0] branch,
   output var logic alu_src,
   output var logic reg_dst,
+  output var logic reg_ra,
   output var logic reg_write,
   output var logic jump,
   output var logic [2:0] alu_control
@@ -23,95 +25,124 @@ always_comb begin
   casez (op)
     // R-type
     6'b000000: begin
-      reg_write <= 1;
-      reg_dst <= 1;
-      branch <= 2'b00;
-      mem_write <= 0;
-      mem_to_reg <= 0;
-      alu_op <= 2'b10;
-      jump <= 0;
+      reg_write = 1;
+      reg_dst = 1;
+      reg_ra = 0;
+      branch = 2'b00;
+      mem_write = 0;
+      mem_to_reg = 0;
+      pc_to_reg = 0;
+      alu_op = 2'b10;
+      jump = 0;
       if (funct == 6'b000000) begin
-        alu_src <= 1;
+        alu_src = 1;
       end
       else begin
-        alu_src <= 0;
+        alu_src = 0;
       end
     end
     // lw
     6'b100011: begin
-      reg_write <= 1;
-      reg_dst <= 0;
-      alu_src <= 1;
-      branch <= 2'b00;
-      mem_write <= 0;
-      mem_to_reg <= 1;
-      alu_op <= 2'b00;
-      jump <= 0;
+      reg_write = 1;
+      reg_dst = 0;
+      reg_ra = 0;
+      alu_src = 1;
+      branch = 2'b00;
+      mem_write = 0;
+      mem_to_reg = 1;
+      pc_to_reg = 0;
+      alu_op = 2'b00;
+      jump = 0;
     end
     // sw
     6'b101011: begin
-      reg_write <= 0;
-      reg_dst <= 1'bx;
-      alu_src <= 1;
-      branch <= 2'b00;
-      mem_write <= 1;
-      mem_to_reg <= 1'bx;
-      alu_op <= 2'b00;
-      jump <= 0;
+      reg_write = 0;
+      reg_dst = 1'bx;
+      reg_ra = 1'bx;
+      alu_src = 1;
+      branch = 2'b00;
+      mem_write = 1;
+      mem_to_reg = 1'bx;
+      pc_to_reg = 1'bx;
+      alu_op = 2'b00;
+      jump = 0;
     end
     // beq
     6'b000100: begin
-      reg_write <= 0;
-      reg_dst <= 1'bx;
-      alu_src <= 0;
-      branch <= 2'b01;
-      mem_write <= 0;
-      mem_to_reg <= 1'bx;
-      alu_op <= 2'b01;
-      jump <= 0;
+      reg_write = 0;
+      reg_dst = 1'bx;
+      reg_ra = 1'bx;
+      alu_src = 0;
+      branch = 2'b01;
+      mem_write = 0;
+      mem_to_reg = 1'bx;
+      pc_to_reg = 1'bx;
+      alu_op = 2'b01;
+      jump = 0;
     end
     // bne
     6'b000101: begin
-      reg_write <= 0;
-      reg_dst <= 1'bx;
-      alu_src <= 0;
-      branch <= 2'b11;
-      mem_write <= 0;
-      mem_to_reg <= 1'bx;
-      alu_op <= 2'b01;
-      jump <= 0;
+      reg_write = 0;
+      reg_dst = 1'bx;
+      reg_ra = 1'bx;
+      alu_src = 0;
+      branch = 2'b11;
+      mem_write = 0;
+      mem_to_reg = 1'bx;
+      pc_to_reg = 1'bx;
+      alu_op = 2'b01;
+      jump = 0;
     end
     // addi, addiu
     6'b00100?: begin
-      reg_write <= 1;
-      reg_dst <= 0;
-      alu_src <= 1;
-      branch <= 2'b00;
-      mem_write <= 0;
-      mem_to_reg <= 0;
-      alu_op <= 2'b00;
-      jump <= 0;
+      reg_write = 1;
+      reg_dst = 0;
+      reg_ra = 0;
+      alu_src = 1;
+      branch = 2'b00;
+      mem_write = 0;
+      mem_to_reg = 0;
+      pc_to_reg = 0;
+      alu_op = 2'b00;
+      jump = 0;
     end
     // j
     6'b000010: begin
-      reg_write <= 0;
-      reg_dst <= 1'bx;
-      alu_src <= 1'bx;
-      branch <= 2'bxx;
-      mem_write <= 0;
-      mem_to_reg <= 1'bx;
-      alu_op <= 2'bxx;
-      jump <= 1;
+      reg_write = 0;
+      reg_dst = 1'bx;
+      reg_ra = 1'bx;
+      alu_src = 1'bx;
+      branch = 2'bxx;
+      mem_write = 0;
+      mem_to_reg = 1'bx;
+      pc_to_reg = 1'bx;
+      alu_op = 2'bxx;
+      jump = 1;
+    end
+    // jal
+    6'b000011: begin
+      reg_write = 1;
+      reg_dst = 1'bx;
+      reg_ra = 1;
+      alu_src = 1'bx;
+      branch = 2'bxx;
+      mem_write = 0;
+      mem_to_reg = 1'bx;
+      pc_to_reg = 1;
+      alu_op = 2'bxx;
+      jump = 1;
     end
     default: begin
-      reg_write <= 1'bx;
-      reg_dst <= 1'bx;
-      alu_src <= 1'bx;
-      branch <= 2'bxx;
-      mem_write <= 1'bx;
-      mem_to_reg <= 1'bx;
-      alu_op <= 2'bxx;
-      jump <= 1'bx;
+      reg_write = 1'bx;
+      reg_dst = 1'bx;
+      reg_ra = 1'bx;
+      alu_src = 1'bx;
+      branch = 2'bxx;
+      mem_write = 1'bx;
+      mem_to_reg = 1'bx;
+      pc_to_reg = 1'bx;
+      alu_op = 2'bxx;
+      jump = 1'bx;
     end
   endcase
 end

--- a/src/register_file.sv
+++ b/src/register_file.sv
@@ -11,7 +11,7 @@ module register_file(
   output var logic [31:0] out
 );
 
-logic [31:0] mem[32:0];
+logic [31:0] mem[31:0];
 
 // Initialze registers
 always_ff @(posedge rst) begin


### PR DESCRIPTION
# 目的

#3 

`jal <label>` 命令のサポート

# やった事

ControlUnitに新たに
- 書きこみ先のレジスタを強制的に`$ra` レジスタにする `reg_ra`  信号を追加
- 書きこむデータをpc + 4にする `pc_to_reg` 信号
を追加し、マルチプレクサを回路にいくつか追加して、`jal`の時に、強制的に書きこむ先のレジスタを`$ra`にしつつ、書きこむデータを `pc + 4` にするようにした
