### PR TITLE
feature: Support jr

### DIFF
--- a/asm/rom.asm
+++ b/asm/rom.asm
@@ -3,11 +3,11 @@ start:
     addiu $v0, $zero, 1
     nop
     addi $v0, $v0, 1
-    addi $t0, $v0, 1
     jal hoge
-hoge:
-    bne $t0, $v0, end
-    addu $v0, $v0, $v0
     j end
+hoge:
+    addu $v0, $v0, $v0
+    jr $ra
+    addi $v0, $v0, 1
 end:
     j end

--- a/src/MINI_CPU.sv
+++ b/src/MINI_CPU.sv
@@ -94,7 +94,7 @@ ram ram_u(
   .rd(read_data)
 );
 
-// Increment Program Counter
+// Increment Program Counter & Branch Program Counter
 logic pc_src;
 logic [1:0] branch;
 branch_judge branch_judge_u(.branch, .zero, .y(pc_src));
@@ -120,12 +120,20 @@ mult2 pc_reg_mult(.sel(pc_to_reg), .a(mem_reg_result), .b(pc_plus_4), .y(pc_reg_
 assign wd3 = pc_reg_result;
 
 // Direct jump
+logic jump;
 logic [31:0] pc_jump;
 assign pc_jump[31:28] = pc_plus_4[31:28];
 assign pc_jump[27:0] = instr[25:0] << 2;
-logic jump;
+logic [31:0] direct_jump_pc;
 
-mult2 pc_jump_mult(.sel(jump), .a(branch_next_pc), .b(pc_jump), .y(next_pc));
+mult2 pc_jump_mult(.sel(jump), .a(branch_next_pc), .b(pc_jump), .y(direct_jump_pc));
+
+// Register jump
+logic [31:0] reg_jump;
+assign reg_jump = rd1;
+logic jump_reg;
+
+mult2 pc_reg_jump_mult(.sel(jump_reg), .a(direct_jump_pc), .b(reg_jump), .y(next_pc));
 
 // Control Unit
 control_unit control_unit_u(
@@ -140,7 +148,8 @@ control_unit control_unit_u(
   .reg_dst,
   .reg_ra,
   .reg_write,
-  .jump
+  .jump,
+  .jump_reg
 );
 
 endmodule

--- a/src/control_unit.sv
+++ b/src/control_unit.sv
@@ -10,6 +10,7 @@ module control_unit(
   output var logic reg_ra,
   output var logic reg_write,
   output var logic jump,
+  output var logic jump_reg,
   output var logic [2:0] alu_control
 );
 
@@ -40,6 +41,12 @@ always_comb begin
       else begin
         alu_src = 0;
       end
+      if (funct == 6'b001000) begin
+        jump_reg = 1;
+      end
+      else begin
+        jump_reg = 0;
+      end
     end
     // lw
     6'b100011: begin
@@ -53,6 +60,7 @@ always_comb begin
       pc_to_reg = 0;
       alu_op = 2'b00;
       jump = 0;
+      jump_reg = 0;
     end
     // sw
     6'b101011: begin
@@ -66,6 +74,7 @@ always_comb begin
       pc_to_reg = 1'bx;
       alu_op = 2'b00;
       jump = 0;
+      jump_reg = 0;
     end
     // beq
     6'b000100: begin
@@ -79,6 +88,7 @@ always_comb begin
       pc_to_reg = 1'bx;
       alu_op = 2'b01;
       jump = 0;
+      jump_reg = 0;
     end
     // bne
     6'b000101: begin
@@ -105,6 +115,7 @@ always_comb begin
       pc_to_reg = 0;
       alu_op = 2'b00;
       jump = 0;
+      jump_reg = 0;
     end
     // j
     6'b000010: begin
@@ -118,6 +129,7 @@ always_comb begin
       pc_to_reg = 1'bx;
       alu_op = 2'bxx;
       jump = 1;
+      jump_reg = 0;
     end
     // jal
     6'b000011: begin
@@ -131,6 +143,7 @@ always_comb begin
       pc_to_reg = 1;
       alu_op = 2'bxx;
       jump = 1;
+      jump_reg = 0;
     end
     default: begin
       reg_write = 1'bx;


### PR DESCRIPTION
# 目的

`jal hoge` 等で `$ra` レジスタに退避してあるあたいを元にPCを変更するため `jr` メッセージをサポートする

# やった事

ControlUnitに、PCの変更元としてレジスタを利用するかどうかの `jump_reg` フラグを追加した